### PR TITLE
Lock coverage baseline and surface it in CI summary

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,5 +50,32 @@ download_with_validation \
   "common.scss"
 
 npm install
-npm run test:coverage
+
+# Run tests with coverage; tee output so we can both display it live and
+# scrape the summary for the GitHub Actions step summary.
+coverage_log="$(mktemp -t nav-coverage-XXXXXX.log)"
+trap 'rm -f "$coverage_log"' EXIT
+set -o pipefail
+npm run test:coverage 2>&1 | tee "$coverage_log"
+set +o pipefail
+
+# Publish the coverage output to the GitHub Actions job summary so the
+# percentages are visible without digging into raw logs. We extract from
+# the "% Coverage report" header through the trailing "====" line of the
+# v8 reporter's summary block (state machine: copy lines after the header,
+# stop once we've seen the second band of '=' delimiters).
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## Test coverage"
+    echo ""
+    echo '```'
+    awk '
+      /% Coverage report/ { copy = 1 }
+      copy { print }
+      copy && /^=+$/ { eq_seen++; if (eq_seen == 2) exit }
+    ' "$coverage_log"
+    echo '```'
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
 npm run build

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -25,10 +25,12 @@ export default defineConfig({
         "test-runner.js",
       ],
       all: false,
-      lines: 80,
-      functions: 80,
-      branches: 80,
-      statements: 80,
+      // Baselines captured from current test suite — do not lower without justification.
+      // Raise these whenever coverage improves so regressions are caught in CI.
+      lines: 95.87,
+      functions: 100,
+      branches: 92.46,
+      statements: 95.37,
     },
   },
 });


### PR DESCRIPTION
## Summary
- Bumps vitest coverage thresholds from `80` across the board to the actual measured baseline (statements 95.37, branches 92.46, functions 100, lines 95.87) so any regression fails CI.
- Tees the v8 coverage report into `$GITHUB_STEP_SUMMARY` from `build.sh` so the percentages render directly on the GitHub Actions run.
- Audited the new summary path: only filename + percentages + uncovered line numbers are emitted — no source, env, or secrets.

## Test plan
- [x] `npm run test:coverage` passes locally at the new thresholds
- [x] Simulated CI summary by running build.sh's awk extract against the tee'd log — produced the expected coverage block only
- [ ] Confirm the next CI run shows the "Test coverage" block in the workflow run summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)